### PR TITLE
fix sonar.sh[78650]: sysctl: permission denied on key 'vm.max_map_count'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,7 +152,7 @@ class sonarqube (
     ensure  => file,
     owner   => root,
     group   => root,
-    mode    => '0755',
+    mode    => '0644',
     content => template("${module_name}/sonar.service.erb")
   }
 

--- a/templates/sonar.service.erb
+++ b/templates/sonar.service.erb
@@ -7,7 +7,7 @@ Wants=network-online.target
 LimitNOFILE=65536
 LimitNPROC=4096
 Environment=MAX_MAP_COUNT=262144
-ExecStartPre=/sbin/sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+ExecStartPre=/sbin/sysctl -q -w vm.max_map_count=${MAX_MAP_COUNT}
 ExecStart=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh start
 ExecStop=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh stop
 ExecReload=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh restart

--- a/templates/sonar.service.erb
+++ b/templates/sonar.service.erb
@@ -6,11 +6,14 @@ Wants=network-online.target
 [Service]
 LimitNOFILE=65536
 LimitNPROC=4096
+Environment=MAX_MAP_COUNT=262144
+ExecStartPre=sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
 ExecStart=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh start
 ExecStop=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh stop
 ExecReload=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh restart
 PIDFile=<%= @real_home.to_s -%>/sonar.pid
 Type=forking
+PermissionsStartOnly=true
 User=<%= @user.to_s %>
 
 [Install]

--- a/templates/sonar.service.erb
+++ b/templates/sonar.service.erb
@@ -7,7 +7,7 @@ Wants=network-online.target
 LimitNOFILE=65536
 LimitNPROC=4096
 Environment=MAX_MAP_COUNT=262144
-ExecStartPre=sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+ExecStartPre=/sbin/sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
 ExecStart=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh start
 ExecStop=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh stop
 ExecReload=<%= @installroot.to_s -%>/sonar/bin/<%= @arch.to_s.gsub(/_/,'-') -%>/sonar.sh restart

--- a/templates/sonar.sh.erb
+++ b/templates/sonar.sh.erb
@@ -62,10 +62,6 @@ RUN_AS_USER=<%= @user %>
 # chkconfig: 2345 90 10
 # description: Test Wrapper Sample Application
 
-# Maximum number of VMA (Virtual Memory Areas) a process can own
-MAX_MAP_COUNT=262144
-sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
-
 # Do not modify anything beyond this point
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
fix sonar.sh[78650]: sysctl: permission denied on key 'vm.max_map_count'

Sonar is run by sonar user by default and cannot set sysctl values.