### PR TITLE
Added manage_service boolean

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,6 +92,9 @@
 # @param service
 #   Specifies the name of the SonarQube system service.
 #
+# @param manage_service
+#   If this module should create and mange the service configuration. Defaults to true
+#
 # @param updatecenter
 #   Specifies whether to enable the Update Center.
 #
@@ -131,6 +134,7 @@ class sonarqube (
   String $search_host,
   Integer $search_port,
   String $service,
+  Boolean $manage_service = true,
   Stdlib::Absolutepath $download_dir,
   Boolean $updatecenter,
   String $user,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,28 +22,31 @@ class sonarqube::service {
     after    => '^PIDDIR=',
     multiple => true,
   }
-  -> file { "/etc/init.d/${sonarqube::service}":
-    ensure => link,
-    target => $sonarqube::script,
-  }
 
-  file { "/etc/systemd/system/${sonarqube::service}.service":
-    ensure  => file,
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    content => epp("${module_name}/${sonarqube::service}.service.epp")
-  }
+  if ($sonarqube::manage_service) {
+    file { "/etc/init.d/${sonarqube::service}":
+      ensure => link,
+      target => $sonarqube::script,
+    }
 
-  service { 'sonarqube':
-    ensure     => running,
-    name       => $sonarqube::service,
-    hasrestart => true,
-    hasstatus  => true,
-    enable     => true,
-    require    => [
-      File["/etc/init.d/${sonarqube::service}"],
-      File["/etc/systemd/system/${sonarqube::service}.service"]
-    ]
+    file { "/etc/systemd/system/${sonarqube::service}.service":
+      ensure  => file,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+      content => epp("${module_name}/${sonarqube::service}.service.epp")
+    }
+
+    service { 'sonarqube':
+      ensure     => running,
+      name       => $sonarqube::service,
+      hasrestart => true,
+      hasstatus  => true,
+      enable     => true,
+      require    => [
+        File["/etc/init.d/${sonarqube::service}"],
+        File["/etc/systemd/system/${sonarqube::service}.service"]
+      ]
+    }
   }
 }


### PR DESCRIPTION
This adds an extra boolean flag that provides the possibility to manage the systemd service outside of this module (disable any systemd behaviour). This gives more freedom in configuring its service parameters.

In my case I'd like to manage the service using eyp/systemd which gives me. E.g. I'd like to put the extra required flags (such as `LimitNOFILE` and `LimitNPROC`)  into a drop-in (also supported by the eyp/systemd module).

BTW the existing template as is, is not working with sonarqube 8+ (as it requires double amount of `LimitNOFILE` and `LimitNPROC`), while the current values are hard-coded into the template