### PR TITLE
Systemd service file PIDFile mismatch

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -35,6 +35,7 @@ sonarqube::search_port: 9001
 sonarqube::service: 'sonar'
 sonarqube::sso: {}
 sonarqube::updatecenter: true
+sonarqube::pidfile: 'SonarQube.pid'
 sonarqube::user: 'sonar'
 sonarqube::user_system: true
 sonarqube::version: '8.9.3'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,9 @@
 # @param updatecenter
 #   Specifies whether to enable the Update Center.
 #
+# @param pidfile
+#   Specifies the name of the PID file.
+#
 # @param user
 #   The user for the SonarQube application.
 #
@@ -140,6 +143,7 @@ class sonarqube (
   Boolean $manage_service,
   Stdlib::Absolutepath $download_dir,
   Boolean $updatecenter,
+  String $pidfile,
   String $user,
   Boolean $user_system,
   String $version,

--- a/templates/sonar.properties.epp
+++ b/templates/sonar.properties.epp
@@ -341,6 +341,7 @@ sonar.security.localUsers=<%= $sonarqube::ldap['local_users'] %>
 sonar.authenticator.downcase=<%= $sonarqube::ldap['authenticator_downcase'] %>
 <% } -%>
 
+<% if $sonarqube::ldap['url'] { -%>
 ldap.url=<%= $sonarqube::ldap['url'] %>
 
 <% if $sonarqube::ldap['follow_referrals'] { -%>
@@ -379,7 +380,46 @@ ldap.group.request=<%= $sonarqube::ldap['group_request'] %>
 <% if $sonarqube::ldap['group_id_attribute'] { -%>
 ldap.group.idAttribute=<%= $sonarqube::ldap['group_id_attribute'] %>
 <% } -%>
+<% } elsif $sonarqube::ldap['servers'] { -%>
+ldap.servers=<%= join($sonarqube::ldap['servers'].map | $server | { $server['id'].regsubst(/-\./, '_', 'G') }, ',') %>
 
+<% $sonarqube::ldap['servers'].each | $server | { -%>
+<% $server_id = $server['id'].regsubst(/-\./, '_', 'G') -%>
+ldap.<%= $server_id -%>.realm=<%= $server['realm'] %>
+ldap.<%= $server_id -%>.url=<%= $server['url'] %>
+<% if $server['bind_dn'] { -%>
+ldap.<%= $server_id -%>.bindDn=<%= $server['bind_dn'] %>
+<% } -%>
+<% if $server['bind_password'] { -%>
+ldap.<%= $server_id -%>.bindPassword=<%= $server['bind_password'] %>
+<% } -%>
+<% if $server['user_base_dn'] { -%>
+ldap.<%= $server_id -%>.user.baseDn=<%= $server['user_base_dn'] %>
+<% } -%>
+<% if $server['user_request'] { -%>
+ldap.<%= $server_id -%>.user.request=<%= $server['user_request'] %>
+<% } -%>
+<% if $server['user_real_name_attribute'] { -%>
+ldap.<%= $server_id -%>.user.realNameAttribute=<%= $server['user_real_name_attribute'] %>
+<% } -%>
+<% if $server['user_email_attribute'] { -%>
+ldap.<%= $server_id -%>.user.emailAttribute=<%= $server['user_email_attribute'] %>
+<% } -%>
+<% if $server['group_base_dn'] { -%>
+ldap.<%= $server_id -%>.group.baseDn=<%= $server['group_base_dn'] %>
+<% } -%>
+<% if $server['group_request'] { -%>
+ldap.<%= $server_id -%>.group.request=<%= $server['group_request'] %>
+<% } -%>
+<% if $server['group_id_attribute'] { -%>
+ldap.<%= $server_id -%>.group.idAttribute=<%= $server['group_id_attribute'] %>
+<% } -%>
+<% if $server['authentication'] { -%>
+ldap.<%= $server_id -%>.authentication=<%= $server['authentication'] %>
+<% } -%>
+
+<% } -%>
+<% } -%>
 <% } elsif !empty($sonarqube::pam) { -%>
 
 # PAM authentication

--- a/templates/sonar.service.epp
+++ b/templates/sonar.service.epp
@@ -11,7 +11,7 @@ ExecStartPre=/sbin/sysctl -q -w vm.max_map_count=${MAX_MAP_COUNT}
 ExecStart=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arch,'_','-') -%>/sonar.sh start
 ExecStop=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arch,'_','-') -%>/sonar.sh stop
 ExecReload=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arch,'_','-') -%>/sonar.sh restart
-PIDFile=<%= $sonarqube::home -%>/SonarQube.pid
+PIDFile=<%= $sonarqube::home -%>/<%= $sonarqube::pidfile %>
 Type=forking
 PermissionsStartOnly=true
 User=<%= $sonarqube::user %>


### PR DESCRIPTION
Hi,

I came from the maestrodev/sonarqube module, and I'm currently using SonarQube 8.5.1. I know it's old, and I'm looking to upgrade to LTS first, then latest. But since the maestrodev module isn't maintained anymore, I thought I first upgrade to this module.

When I changed to using this module and keeping the 8.5.1 version, I had an issue with the PID file in the SonarQube home directory. The PID file is created, but it is called `sonar.pid`, and the Systemd service file is looking for `SonarQube.pid`.
SonarQube does start and works, for a short time, but then Systemd times out because it can't find the PID file, and it then terminates SonarQube.

This PR adds a pidfile parameter defaulting to "SonarQube.pid" (which is currently the fixed filename), making us able to configure which PIDFile that Systemd should use if there is a mismatch.