### PR TITLE
Add no proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ class { 'sonarqube':
   },
   web_java_opts => '-Xmx1024m',
   updatecenter  => 'true',
-  http_proxy    => {
-    host        => 'proxy.example.com',
-    port        => '8080',
-    ntlm_domain => '',
-    user        => '',
-    password    => '',
+  http_proxy        => {
+    host            => 'proxy.example.com',
+    port            => '8080',
+    ntlm_domain     => '',
+    user            => '',
+    password        => '',
+    non_proxy_hosts => 'localhost|127.*|[::1]',
   },
   sso             => {
     enable        => 'true',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -123,7 +123,7 @@ Default value: ``undef``
 
 Data type: `Hash`
 
-Specifies the HTTP Proxy that should be used for SonarQube's Update Center.
+Specifies the HTTP Proxy that should be used for SonarQube's Update Center or connection to devops platforms.
 
 ##### `https`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@
 #   Specifies the listen address for SonarQube.
 #
 # @param http_proxy
-#   Specifies the HTTP Proxy that should be used for SonarQube's Update Center.
+#   Specifies the HTTP Proxy that should be used for SonarQube's Update Center or connection to devops platforms.
 #
 # @param https
 #   Specifies the required configuration to enable HTTPS support.

--- a/templates/sonar.properties.epp
+++ b/templates/sonar.properties.epp
@@ -310,6 +310,10 @@ http.auth.ntlm.domain=<%= $sonarqube::http_proxy['ntlm_domain'] %>
 # proxy authentication. The 2 following properties are used for HTTP and SOCKS proxies.
 http.proxyUser=<%= $sonarqube::http_proxy['user'] %>
 http.proxyPassword=<%= $sonarqube::http_proxy['password'] %>
+
+# non proxy hosts (default localhost|127.*|[::1])
+http.nonProxyHosts=<%= $sonarqube::http_proxy['non_proxy_hosts'] %>
+
 <% } -%>
 
 # SOCKS proxy (default none)


### PR DESCRIPTION
When setting proxy options, it is not only used for update, so connection to other local server (local gitlab integration for instance) are potentially blocked. 

By default, this option is added to java cmd line : -Dhttp.nonProxyHosts=localhost|127.*|[::1]

If we override this by "java web opts", the cmd line became "-Dhttp.nonProxyHosts=localhost|127.*|[::1]|*.my.domain  [...] -Dhttp.nonProxyHosts=localhost|127.*|[::1]" and new configuration isn't properly added

The right way to implements this is to add in sonar.properties the line
```
http.nonProxyHosts=localhost|127.*|[::1]|*.my.domain
```


