### PR TITLE
add param systemPasscode

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,9 @@
 # @param helper_dir
 #   Specifies the directory for Sonarqube Helper scripts.
 #
+# @param system_passcode
+#   Optional system_passcode setting for monitoring.
+#
 class sonarqube (
   # required parameters
   String $arch,
@@ -165,6 +168,7 @@ class sonarqube (
   Optional[String] $search_java_additional_opts = undef,
   Optional[Hash] $sso = undef,
   Optional[String] $web_java_opts = undef,
+  Optional[String] $system_passcode = undef,
 ) {
   Exec {
     path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',

--- a/templates/sonar.properties.epp
+++ b/templates/sonar.properties.epp
@@ -241,6 +241,16 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  <% if $sonarqube::jdbc['time_between_
 
 <% } -%>
 
+<% if !empty($sonarqube::system_passcode) { -%>
+# A passcode can be defined to access some web services from monitoring
+# tools without having to use the credentials of a system administrator.
+# Check the Web API documentation to know which web services are supporting this authentication mode.
+# The passcode should be provided in HTTP requests with the header "X-Sonar-Passcode".
+# By default feature is disabled.
+#sonar.web.systemPasscode=
+sonar.web.systemPasscode=<%= $sonarqube::system_passcode %>
+<% } -%>
+
 <% if !empty($sonarqube::sso) { -%>
 #---------------------------------------------------------
 # SSO AUTHENTICATION


### PR DESCRIPTION
SonarQube has added support for prometheus metrics. To be able to scrape them we need to set the `sonar.web.systemPasscode` property in sonar.properties.

https://docs.sonarqube.org/latest/instance-administration/monitoring/#prometheus-monitoring

This PR adds support for setting this.