### PR TITLE
Use RuntimeDirectory

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -52,18 +52,12 @@ class sonarqube::service {
       notify  => Service[$sonarqube::service],
     }
 
-    file { "/run/${sonarqube::service}":
-      ensure => directory,
-      mode   => '0770',
-    }
-
     # Enable systemd service
     service { $sonarqube::service:
       ensure     => running,
       hasrestart => true,
       hasstatus  => true,
       enable     => true,
-      require    => File["/run/${sonarqube::service}"],
     }
   }
 }

--- a/templates/sonar.service.epp
+++ b/templates/sonar.service.epp
@@ -12,6 +12,7 @@ ExecStart=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arc
 ExecStop=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arch,'_','-') -%>/sonar.sh stop
 ExecReload=<%= $sonarqube::installroot -%>/sonar/bin/<%= regsubst($sonarqube::arch,'_','-') -%>/sonar.sh restart
 PIDFile=/run/<%= $sonarqube::service -%>/<%= $sonarqube::pidfile %>
+RuntimeDirectory=<%= $sonarqube::service %>
 Type=forking
 PermissionsStartOnly=true
 User=<%= $sonarqube::user %>


### PR DESCRIPTION
Fix for:
```
systemd[1]: sonar.service: Can't open PID file /run/sonar/SonarQube.pid (yet?) after start: Operation not permitted
```